### PR TITLE
公式Twitterクライアント用Linkerを実装

### DIFF
--- a/lib/linker/linker.rb
+++ b/lib/linker/linker.rb
@@ -11,4 +11,4 @@ end
 
 require_relative "http_linker"
 require_relative "tweetbot_linker"
-require_relative "twitterOfficial_linker"
+require_relative "twitter_linker"

--- a/lib/linker/twitter_linker.rb
+++ b/lib/linker/twitter_linker.rb
@@ -1,5 +1,5 @@
 class TwentyNineHours
-  class Twitter_officialLinker < Linker
+  class TwitterLinker < Linker
     def build(tweet)
       "twitter://status?id=%d" % [tweet["id_str"]]
     end


### PR DESCRIPTION
公式Twitterクライアント（Twitter for iOS）に対応したLinkerを実装しました。
`twitterOfficial_linker.rb`に該当機能を新規実装し、`linker.rb`に呼んであげる処理を追記しました。
