### PR TITLE
Available to update settings without restarting 29hours

### DIFF
--- a/29hours.rb
+++ b/29hours.rb
@@ -12,6 +12,4 @@ require_relative "lib/twenty_nine_hours"
 
 path = ENV["SETTINGS_FILE_PATH"] || File.join(__dir__, "settings.yml")
 
-settings = YAML.load(open(path))
-
-TwentyNineHours.new(settings).watch
+TwentyNineHours.new(path).watch


### PR DESCRIPTION
- Change initial args `TwentyNineHours`: settings -> path
- Add periodic task to  `TwentyNineHours::Streamer`
-  `TwentyNineHours::Streamer` accepts changing matchers, notifiers and linker
- Add a periodic task to checking and updating setting

I'd to update settings without restarting 29hours.rb :space_invader: 
