### PR TITLE
Avoid EOFError

### DIFF
--- a/lib/twenty_nine_hours.rb
+++ b/lib/twenty_nine_hours.rb
@@ -72,6 +72,9 @@ class TwentyNineHours
       @client.user do |data|
         handle(data)
       end
+    rescue EOFError
+      LOGGER.info "EOFError occured. Retry."
+      retry
     end
 
     private


### PR DESCRIPTION
さくらの VPS で 29hours を使わせて頂いております。:bow:

たまに以下のログを吐いて落ちているので、修正してみました。
いかがでしょうか？

```
/home/masutaka/.rbenv/versions/2.2.2/lib/ruby/2.2.0/openssl/buffering.rb:129:in `sysread': end of file reached (EOFError)
        from /home/masutaka/.rbenv/versions/2.2.2/lib/ruby/2.2.0/openssl/buffering.rb:129:in `readpartial'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/connection.rb:21:in `stream'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/client.rb:118:in `request'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/client.rb:91:in `user'
        from /opt/masutaka-29hours/releases/20150829060219/29hours/lib/twenty_nine_hours.rb:72:in `start'
        from /opt/masutaka-29hours/releases/20150829060219/29hours/lib/twenty_nine_hours.rb:39:in `watch'
        from 29hours.rb:17:in `<main>'
```

[Twitter gem でも話に出ていて](https://github.com/sferik/twitter/issues/535#issuecomment-35912653)、 https://github.com/sferik/twitter/issues/535 が [v6 のマイルストーン](https://github.com/sferik/twitter/milestones/v6)に上がっています。
でも、いつ対応されるか分からないので、29hours で対応しても良いかなと思いました。
